### PR TITLE
Fixed result history resetting to 0 on rerun and removed unused arguments in functions

### DIFF
--- a/pkg/result/chaosresult.py
+++ b/pkg/result/chaosresult.py
@@ -81,20 +81,20 @@ class ChaosResults(object):
 	#PatchChaosResult Update the chaos result
 	def PatchChaosResult(self, clients, result, chaosDetails, resultDetails, chaosResultLabel):
 		
-		passedRuns = 0 
-		failedRuns = 0 
-		stoppedRuns = 0
+		passedRuns = result.status.history.passedRuns
+		failedRuns = result.status.history.failedRuns
+		stoppedRuns = result.status.history.stoppedRuns
+
 		#isAllProbePassed, probeStatus = self.GetProbeStatus(resultDetails)
 		if str(resultDetails.Phase).lower() == "completed":
-			
 			if str(resultDetails.Verdict).lower() == "pass":
 				probeSuccessPercentage = "100"
-				passedRuns = result.status.history.passedRuns + 1
+				passedRuns += 1
 			elif str(resultDetails.Verdict).lower() == "fail":
-				failedRuns =  result.status.history.failedRuns + 1
+				failedRuns += 1
 				probeSuccessPercentage = "0"
 			elif str(resultDetails.Verdict).lower() == "stopped":
-				stoppedRuns = result.status.history.stoppedRuns + 1
+				stoppedRuns += 1
 				probeSuccessPercentage = "0"
 		else:
 			probeSuccessPercentage = "Awaited"


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR will fix the issue where passed, failed and stopped counts in chaosresult is getting reset to 0 on re-run of same experiment.
Also, done cleanup of unused arguments in functions.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #46 

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] PR messages has document related information
-   [ ] Labelled this PR & related issue with `breaking-changes` tag
-   [ ] PR messages has breaking changes related information
-   [ ] Labelled this PR & related issue with `requires-upgrade` tag
-   [ ] PR messages has upgrade related information
-   [ ] Commit has unit tests
-   [ ] Commit has integration tests
-   [ ] E2E run Required for the changes
